### PR TITLE
adds SERVER_NAME to config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@ import os
 
 class base_config(object):
     SITE_NAME = 'Flask Bones'
+    SERVER_NAME = os.environ.get('SERVER_NAME')
     SECRET_KEY = os.environ.get('SECRET_KEY')
     BROKER_URL = os.environ.get('REDISCLOUD_URL', 'redis://127.0.0.1:6379')
     BROKER_BACKEND = os.environ.get('REDISCLOUD_URL', 'redis://127.0.0.1:6379')


### PR DESCRIPTION
In order to generate external URL's, Flask expects a `SERVER_NAME` config property.
