### PR TITLE
Generate timestamps in DB

### DIFF
--- a/app/user/models.py
+++ b/app/user/models.py
@@ -9,7 +9,10 @@ class User(CRUDMixin, UserMixin, db.Model):
     username = db.Column(db.String(20), nullable=False, unique=True)
     email = db.Column(db.String(128), nullable=False, unique=True)
     pw_hash = db.Column(db.String(60), nullable=False)
-    created_ts = db.Column(db.DateTime(), nullable=False)
+    created_ts = db.Column(db.DateTime(timezone=True),
+            server_default=db.func.current_timestamp(),)
+    updated_ts = db.Column(db.DateTime(timezone=True),
+            onupdate=db.func.current_timestamp(),)
     remote_addr = db.Column(db.String(20))
     active = db.Column(db.Boolean())
     is_admin = db.Column(db.Boolean())


### PR DESCRIPTION
Better to generate timestamps in DB due to clock drift in app servers, varying network latency, etc. Downside is this uses DB transaction timestamp, so all objects created within single DB transaction will have the same created time, but that's an acceptable tradeoff. Fix #26