### PR TITLE
replacing cachecore with werkzeug.contrib.cache

### DIFF
--- a/app/extensions.py
+++ b/app/extensions.py
@@ -13,7 +13,7 @@ travis = Travis()
 from flask.ext.mail import Mail
 mail = Mail()
 
-from cachecore import SimpleCache
+from werkzeug.contrib.cache import SimpleCache
 cache = SimpleCache()
 
 from flask.ext.bcrypt import Bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,6 @@ anyjson==0.3.3
 argparse==1.1
 billiard==2.7.3.32
 blinker==1.3
-cachecore==0.1.0
 celery==3.0.23
 celery-with-redis==3.0
 coverage==3.6


### PR DESCRIPTION
replacing cachecore with werkzeug.contrib.cache whihc was already installed. Cachecore is based on werkzeug.contrib.cache. Cachecore's Pypi page was 404ing per https://github.com/cburmeister/flask-bones/issues/31