### PR TITLE
Broaden configuration options for Flask

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,8 +16,10 @@ from app.utils import url_for_other_page
 
 def create_app(config=config.base_config):
     """Returns an initialized Flask application."""
-    app = Flask(__name__)
+    app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(config)
+    app.config.from_pyfile('app.cfg', silent=True)
+    app.config.from_envvar('CONFIG_FILE', silent=True)
 
     register_extensions(app)
     register_blueprints(app)

--- a/instance/app.cfg.sample
+++ b/instance/app.cfg.sample
@@ -1,0 +1,1 @@
+SERVER_NAME="localhost:5000"


### PR DESCRIPTION
Enables a relative instance directory, which prevents config and other artifacts from being dropped in he `app/` folder with source code.

Add supports for loading config from `instance/app.cfg` or from arbitrary file pointed to by `CONFIG_FILE` environment variable.