### PR TITLE
Fix broken asset merge when running outside of dev mode

### DIFF
--- a/app/assets.py
+++ b/app/assets.py
@@ -1,7 +1,12 @@
 from flask_assets import Bundle, Environment, Filter
 
-# fixes missing semicolon in last statement of jquery.pjax.js
 class ConcatFilter(Filter):
+    """
+    Filter that merges files, placing a semicolon between them.
+
+    Fixes issues caused by missing semicolons at end of JS assets, for example
+    with last statement of jquery.pjax.js.
+    """
     def concat(self, out, hunks, **kw):
         out.write(';'.join([h.data() for h, info in hunks]))
 

--- a/app/assets.py
+++ b/app/assets.py
@@ -1,4 +1,9 @@
-from flask_assets import Bundle, Environment
+from flask_assets import Bundle, Environment, Filter
+
+# fixes missing semicolon in last statement of jquery.pjax.js
+class ConcatFilter(Filter):
+    def concat(self, out, hunks, **kw):
+        out.write(';'.join([h.data() for h, info in hunks]))
 
 js = Bundle(
     'node_modules/jquery/dist/jquery.js',
@@ -6,9 +11,10 @@ js = Bundle(
     'node_modules/bootbox/bootbox.js',
     'node_modules/bootstrap/dist/js/bootstrap.min.js',
     'js/application.js',
-    filters='jsmin',
+    filters=(ConcatFilter, 'jsmin'),
     output='gen/packed.js'
 )
+
 css = Bundle(
     'node_modules/bootstrap/dist/css/bootstrap.css',
     'node_modules/font-awesome/css/font-awesome.css',

--- a/app/assets.py
+++ b/app/assets.py
@@ -19,9 +19,10 @@ css = Bundle(
     'node_modules/bootstrap/dist/css/bootstrap.css',
     'node_modules/font-awesome/css/font-awesome.css',
     'css/style.css',
-    filters='cssmin',
+    filters=('cssmin','cssrewrite'),
     output='gen/packed.css'
 )
+
 assets = Environment()
 assets.register('js_all', js)
 assets.register('css_all', css)


### PR DESCRIPTION
Enabling production config / asset merging results in a broken website because:
1. Relative asset references (like fonts) are not rewritten in CSS
2. jquery-pjax does not include a semicolon on its last statement (an IIEF), causing syntax errors on file merge ((see here)[https://github.com/miracle2k/webassets/issues/100#issuecomment-388461033])

This PR addresses both issues.