### PR TITLE
escaping user provided variables in Jinja templates

### DIFF
--- a/app/auth/templates/mail/registration.mail
+++ b/app/auth/templates/mail/registration.mail
@@ -1,4 +1,4 @@
-Welcome {{ user.username }},
+Welcome {{ user.username|e}},
 
 Please follow the link below to finish your registration.
 


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates.

You are passing the `user` parameter to your jinja template in app/jobs.py:17. I looked and couldn't quite tell if the `user.username` value is html escaped, so I went ahead and fixed that in the mail/registration template using the `{{user.username|e}}` pattern. (https://jinja.palletsprojects.com/en/2.10.x/templates/#working-with-manual-escaping). Hopefully, you'll find this PR useful.

Otherwise, your code is really clean (we ran eslint, flake8, bandit and our custom checks). If you are curious, feel free download and give Bento a try (https://bento.dev)